### PR TITLE
Fix image reference by pointing to quay.io

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: multicloud-operators-placementrule
           # Replace this with the built image name
-          image: REPLACE_IMAGE
+          image: quay.io/multicloudlab/multicloud-operators-placementrule
           command:
           - multicloud-operators-placementrule
           imagePullPolicy: Always


### PR DESCRIPTION
image is set to quay.io/multicloudlab/multicloud-operators-placementrule

Signed-off-by: Richard Su <rwsu@redhat.com>